### PR TITLE
feat: add RSS feed auto-discovery link tag

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -29,3 +29,6 @@ const { title, description, ogImage = '/placeholder-social.jpg' } = Astro.props;
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:creator" content="@passincat" />
+
+<!-- RSS -->
+<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />


### PR DESCRIPTION
## Summary
- RSSフィードの自動発見用リンクタグを`<head>`に追加
- これによりInoreaderなどのRSSリーダーがドメインからフィードを自動検出可能に

## Test plan
- [ ] デプロイ後、https://blog.keisatoh.net/ のソースで `<link rel="alternate" type="application/rss+xml"` が含まれていることを確認
- [ ] Inoreaderでドメインを入力してRSSフィードが検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)