### PR TITLE
fix(ci): use v3 tag for wrangler-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: touch dist/.assetsignore
 
-      - uses: cloudflare/wrangler-action@da0e0245e6f40f5f2d978c7d56c153c0e050457b # v3.14.0
+      - uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- wrangler-actionのSHA指定が無効だったためv3タグを使用するように修正

## Test plan
- [ ] CIが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)