### PR TITLE
perf: add cache headers for Astro assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Astro assets (hashed filenames - safe for long-term caching)
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Fonts
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Astroのハッシュ付きアセット（`/_astro/*`）に1年間のキャッシュを設定
- フォント（`/fonts/*`）にも同様のキャッシュを設定
- Lighthouseのキャッシュポリシー指摘に対応

## Background
Lighthouse計測で以下の問題が検出されました:
- `_astro/*.css` が `Cache-Control: max-age=0` で配信されていた
- Astroのハッシュ付きアセットは内容が変わるとファイル名も変わるため、長期キャッシュが安全

## Changes
`public/_headers` ファイルを追加し、Cloudflare Workersで以下のキャッシュヘッダーを適用:
```
/_astro/*
  Cache-Control: public, max-age=31536000, immutable
```

## Test plan
- [ ] デプロイ後、DevToolsのNetworkタブでCSS/JSのCache-Controlヘッダーを確認
- [ ] Lighthouseで再計測し、キャッシュ警告が解消されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)