### PR TITLE
fix(a11y): improve text contrast ratio for WCAG AA compliance

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        gray: '#888888',
+        gray: '#737373',
       },
       typography: (theme: (path: string) => string) => ({
         DEFAULT: {


### PR DESCRIPTION
## Summary
- テキストのコントラスト比をWCAG AA基準（4.5:1以上）に準拠するよう修正
- gray色を `#888888`（3.5:1）から `#737373`（4.85:1）に変更

## Background
Lighthouse監査で以下の警告が検出されました:
> Background and foreground colors do not have a sufficient contrast ratio.

影響を受ける箇所:
- 記事一覧の日付
- 記事詳細ページの日付・説明文
- blockquoteのテキスト

## Test plan
- [ ] デプロイ後、Lighthouseでアクセシビリティスコアを確認
- [ ] コントラスト警告が解消されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)