### PR TITLE
chore: add Dependabot with bun lockfile auto-update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-bun.yml
+++ b/.github/workflows/dependabot-bun.yml
@@ -1,0 +1,35 @@
+name: Update bun.lockb for Dependabot PRs
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Update bun.lockb
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bun.lockb
+          git diff --staged --quiet || git commit -m "chore: update bun.lockb"
+          git push


### PR DESCRIPTION
## Summary
- Dependabotを導入し、依存関係の自動更新を設定
- npmパッケージとGitHub Actionsを週1回チェック
- DependabotのPR作成時にbun.lockbを自動更新するワークフローを追加

## Test plan
- [ ] PRがマージされたらDependabotが有効になることを確認
- [ ] 次回のDependabot PRでbun.lockbが自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)