### PR TITLE
a11y: improve accessibility

### DIFF
--- a/src/components/GoBackButton.astro
+++ b/src/components/GoBackButton.astro
@@ -1,6 +1,6 @@
 <a
   href="/"
-  aria-label="Go back to top page"
+  aria-label="トップページに戻る"
   class="inline-block rounded-lg border border-slate-400 bg-white px-5 py-1 text-center text-xs font-medium text-gray-900 ring-slate-400 transition duration-200 outline-none hover:bg-gray-100 hover:text-indigo-700 focus-visible:ring-2 active:bg-gray-200 sm:text-sm"
   >&larr; トップに戻る</a
 >

--- a/src/components/GoBackButton.astro
+++ b/src/components/GoBackButton.astro
@@ -1,5 +1,6 @@
 <a
   href="/"
+  aria-label="Go back to top page"
   class="inline-block rounded-lg border border-slate-400 bg-white px-5 py-1 text-center text-xs font-medium text-gray-900 ring-slate-400 transition duration-200 outline-none hover:bg-gray-100 hover:text-indigo-700 focus-visible:ring-2 active:bg-gray-200 sm:text-sm"
-  >← トップに戻る</a
+  >&larr; トップに戻る</a
 >

--- a/src/components/SocialButtons.astro
+++ b/src/components/SocialButtons.astro
@@ -2,7 +2,7 @@
   <a
     class="twitter-share-button"
     href="https://twitter.com/intent/tweet"
-    aria-label="Share this article on Twitter"
+    aria-label="この記事をTwitterでシェア"
     data-size="large">ツイート</a
   >
   <a

--- a/src/components/SocialButtons.astro
+++ b/src/components/SocialButtons.astro
@@ -2,9 +2,14 @@
   <a
     class="twitter-share-button"
     href="https://twitter.com/intent/tweet"
+    aria-label="Share this article on Twitter"
     data-size="large">ツイート</a
   >
-  <a href="https://www.buymeacoffee.com/keisatoh" target="_blank"
+  <a
+    href="https://www.buymeacoffee.com/keisatoh"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Buy me a coffee"
     ><img
       src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
       alt="Buy Me A Coffee"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,7 @@ const posts = (await getCollection("posts")).sort(
   ogImage="/og/index.png"
 >
   <div class="prose lg:prose-lg mx-auto">
+    <h1 class="sr-only">Posts</h1>
     <div class="not-prose">
       {
         posts.map((post) => (


### PR DESCRIPTION
## Summary

Improve accessibility for screen readers and keyboard navigation.

## Changes

- Add `aria-label` to GoBackButton
- Add `aria-label` to Twitter share button and Buy Me a Coffee link
- Add `rel="noopener noreferrer"` to external links
- Add `h1` (screen reader only) to index page for proper heading hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)