### PR TITLE
refactor: add formatDate utility

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,12 @@
 ---
 
-import { getCollection } from "astro:content";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../../config";
-import { getExcerpt } from "../utils";
-import Layout from "../layouts/Layout.astro";
+import { getCollection } from 'astro:content';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../../config';
+import { getExcerpt } from '../utils';
+import { formatDate } from '../utils/date';
+import Layout from '../layouts/Layout.astro';
 
-const posts = (await getCollection("posts")).sort(
+const posts = (await getCollection('posts')).sort(
   (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf(),
 );
 ---
@@ -21,11 +22,7 @@ const posts = (await getCollection("posts")).sort(
         posts.map((post) => (
           <article class="[&:nth-child(n+2)]:mt-10">
             <time datetime={post.data.date} class="text-gray text-sm">
-              {new Date(post.data.date).toLocaleDateString("ja-JP", {
-                year: "numeric",
-                month: "short",
-                day: "numeric",
-              })}
+              {formatDate(post.data.date)}
             </time>
             <h2 class="mt-1 text-xl font-normal text-black hover:text-indigo-700 sm:mt-2 sm:text-3xl">
               <a href={`/posts/${post.id.replace(/\.md$/, "")}/`}>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,10 +1,11 @@
 ---
 
-import { getCollection } from "astro:content";
-import GoBackButton from "../../components/GoBackButton.astro";
-import SocialButtons from "../../components/SocialButtons.astro";
-import { getExcerpt } from "../../utils";
-import Layout from "../../layouts/Layout.astro";
+import { getCollection } from 'astro:content';
+import GoBackButton from '../../components/GoBackButton.astro';
+import SocialButtons from '../../components/SocialButtons.astro';
+import { getExcerpt } from '../../utils';
+import { formatDate } from '../../utils/date';
+import Layout from '../../layouts/Layout.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
@@ -34,13 +35,7 @@ const ogImageSrc = ogImage?.src ?? `/og/${slug}.png`;
   >
     <div class="not-prose">
       <time datetime={date} class="text-gray text-sm">
-        {
-          new Date(date).toLocaleDateString("ja-JP", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-          })
-        }
+        {formatDate(date)}
       </time>
       <h1 class="mt-1 text-3xl font-normal text-black md:text-5xl">
         {title}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,7 @@
+export function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}


### PR DESCRIPTION
## Summary

Add `formatDate` utility function to eliminate duplicate date formatting code.

## Changes

- Add `src/utils/date.ts` with `formatDate` function
- Use `formatDate` in `index.astro` and `[...slug].astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)